### PR TITLE
Menu option for choosing grenade start behaviour in NM and UNM

### DIFF
--- a/CVARINFO.txt
+++ b/CVARINFO.txt
@@ -48,6 +48,8 @@ server bool D4D_DemonNameDisplay  = True;
 server int D4D_HasteSpawn = 1; //Sometimes
 server bool D4D_EnhancedChase = true;
 server bool D4D_BerserkAutoSwitch = true;
+server int D4D_NMareGrenades = 2; // [0,1,2] = [none,frag,all]
+
 
 // The Zombie Killer's Footsteps
 server float fs_volume_mul = 1.4;

--- a/CVARINFO.txt
+++ b/CVARINFO.txt
@@ -48,7 +48,7 @@ server bool D4D_DemonNameDisplay  = True;
 server int D4D_HasteSpawn = 1; //Sometimes
 server bool D4D_EnhancedChase = true;
 server bool D4D_BerserkAutoSwitch = true;
-server int D4D_NMareGrenades = 2; // [0,1,2] = [none,frag,all]
+server int D4D_NMGrenades = 2; // [0,1,2] = [none,frag,all]
 
 
 // The Zombie Killer's Footsteps

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -83,6 +83,7 @@ OptionMenu "D4DOptions"
 	Option "Ledge grabbing",				"d4d_allowClimbing",	"OnOff"
 	Option "Syphon strength",				"user_SyphonStrength",	"SyphonStrength"
 	Option "Berserk Switch On Pickup",		"D4D_BerserkAutoSwitch","YesNo"
+	Option "Nightmare Grenade Starts",		"D4D_NMGrenades","NMGrenade"
 	StaticText ""
 	StaticText "Monster Behaviour", 1
 	Option "Enhanced Monster Chasing",		"D4D_EnhancedChase",	"OnOff"
@@ -258,6 +259,13 @@ OptionMenu "D4DGoreOptions"
 	StaticText " "
 	NumberField "Bullet Giblets Unleashed",		"user_Giblets",	0, 10000, 1
 	NumberField "Splatter Giblets Unleashed",	"user_SplatterGiblets",	0, 10000, 1
+}
+
+OptionValue "NMGrenade"
+{
+	0, "Off"
+	1, "Frag Only"
+	2, "All"
 }
 
 OptionValue "HasteSpawn"

--- a/ZD4D/Doom4Player.txt
+++ b/ZD4D/Doom4Player.txt
@@ -89,16 +89,26 @@ Class Doom4Player : PlayerPawn
 				{
 					if (GetCvar("skill") >= 3)
 					{
+					  if (GetCvar("D4D_NMGrenades") >= 1) //Give and select frag if the setting isn't "Off" 
+					  {
 						if (!CountInv("FragGrenadePickup"))
-						{	A_GiveInventory("FragGrenadePickup",1);	}
-						if (!CountInv("HoloGrenadePickup"))
-						{	A_GiveInventory("HoloGrenadePickup",1);	}
-						if (!CountInv("SyphonGrenadePickup"))
 						{	
-							A_GiveInventory("SyphonGrenadePickup",1);
-							A_GiveInventory("SyphonGrenadeSelected",1);
+						  A_GiveInventory("FragGrenadePickup",1);
+						  A_GiveInventory("FragGrenadeSelected",1);
 						}
+					  }
+					  if (GetCvar("D4D_NMGrenades") >= 2) //Give the rest and select syphon if the setting is "All"
+					  {
+					    	if (!CountInv("HoloGrenadePickup"))
+						    {	A_GiveInventory("HoloGrenadePickup",1);	}
+						if (!CountInv("SyphonGrenadePickup"))
+						    {   A_GiveInventory("SyphonGrenadePickup",1);
+		      				        A_TakeInventory("FragGrenadeSelected",1);
+							A_TakeInventory("HoloGrenadeSelected",1); //Just in case
+						        A_GiveInventory("SyphonGrenadeSelected",1); }
+					  }
 					}
+					
 					A_SetInventory("D4MultiJump",int(GetCvar("D4MultiJump")));
 					user_rollmove = user_rollpain = user_rollsave = user_offsets =
 					user_vel = user_zvel = user_hold = user_time = user_vel2 = 

--- a/ZD4D/Doom4Player.txt
+++ b/ZD4D/Doom4Player.txt
@@ -104,7 +104,7 @@ Class Doom4Player : PlayerPawn
 						if (!CountInv("SyphonGrenadePickup"))
 						    {   A_GiveInventory("SyphonGrenadePickup",1);
 		      				        A_TakeInventory("FragGrenadeSelected",1);
-							A_TakeInventory("HoloGrenadeSelected",1); //Just in case
+							A_TakeInventory("MarineHoloSelected",1); //Just in case
 						        A_GiveInventory("SyphonGrenadeSelected",1); }
 					  }
 					}


### PR DESCRIPTION
This adds a cvar "D4D_NMGrenades" that the player can toggle from the menu to decide what grenades they start with in NM and UNM difficulties.
0 = "Off" , the player doesn't start with any grenades in NM or UNM.
1 = "Frag Only", the player starts with just the frag grenade.
2 = "All", start the player off with all 3 grenade types. This is the old behavior and is set as default.

Tested in GZD stable 2.3
Files modified:
Cvarinfo - Setting up the cvar
MenuDef - Integration of the cvar into the menu
Doom4 Player definition - Expands the existing definition in the NewMapToken block.